### PR TITLE
Add missing environment variables

### DIFF
--- a/config/production.yaml
+++ b/config/production.yaml
@@ -6,3 +6,4 @@ PLAINTEXT_VARIABLES:
   REGION: us-east-1
   REFINERY_API_BASE_URL: "https://refinery.nypl.org/api/nypl/locations/v1.0/locations/"
   TZ: America/New_York
+  RC_ALERTS_URL: https://raw.githubusercontent.com/NYPL/locations-service/scc-3844/data/princeton-closures.csv

--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -44,6 +44,7 @@ resource "aws_lambda_function" "lambda_instance" {
   environment {
     variables = {
       ENVIRONMENT = var.environment
+      # In order to calculate correct offsets, we need to set the default time zone at deploy time or else AWS will ignore it:
       TZ = "America/New_York"
     }
   }

--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -44,6 +44,7 @@ resource "aws_lambda_function" "lambda_instance" {
   environment {
     variables = {
       ENVIRONMENT = var.environment
+      TZ = "America/New_York"
     }
   }
 }


### PR DESCRIPTION
Adds a couple of missing environment variables:

- Set `TZ` at deploy time
- Production was missing the `RC_ALERTS_URL` for some reason.