### PR TITLE
[SCC-3650] Use drupal API for locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ test-verbose:
 	pytest -v -r P
 
 lint:
-	flake8 --exclude *env,.aws-sam/*
+	flake8 --max-line-length=120 --exclude *env,.aws-sam/*

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -5,5 +5,6 @@ PLAINTEXT_VARIABLES:
   S3_LOCATIONS_FILE: locations.json
   REGION: us-east-1
   REFINERY_API_BASE_URL: "https://refinery.nypl.org/api/nypl/locations/v1.0/locations/"
+  DRUPAL_API_BASE_URL: "https://qa-drupal.nypl.org/jsonapi/node/library"
   RC_ALERTS_URL: https://raw.githubusercontent.com/NYPL/locations-service/scc-3844/data/princeton-closures.csv
   TZ: America/New_York

--- a/events/ma.json
+++ b/events/ma.json
@@ -1,0 +1,10 @@
+{
+  "resource": "/api/v0.1/locations",
+  "path": "/api/v0.1/locations",
+  "httpMethod": "GET",
+  "isBase64Encoded": false,
+  "queryStringParameters": {
+    "location_codes": "ma",
+    "fields": "url,hours,location"
+  }
+}

--- a/lib/location_api.py
+++ b/lib/location_api.py
@@ -1,0 +1,153 @@
+import requests
+import json
+import os
+import datetime
+
+from dateutil.parser import parse
+from functools import cache
+from requests.exceptions import JSONDecodeError, RequestException
+
+from lib.logger import GlobalLogger
+from lib.errors import RefineryApiError
+from lib.rc_alerts import RCAlerts
+
+
+GlobalLogger.initialize_logger(__name__)
+logger = GlobalLogger.logger
+
+INTEGER_DAYS = {
+    "MONDAY": 0,
+    "TUESDAY": 1,
+    "WEDNESDAY": 2,
+    "THURSDAY": 3,
+    "FRIDAY": 4,
+    "SATURDAY": 5,
+    "SUNDAY": 6
+}
+
+@cache
+def get_location_by_code(code):
+    try:
+        response = requests.get(
+            os.environ['DRUPAL_API_BASE_URL'] + '?filter[field_ts_location_code]=' + code
+        )
+        response.raise_for_status()
+        response = response.json()
+        if not response.get('data'):
+            return None
+        return response.get('data')[0].get('attributes', None)
+    except RequestException as e:
+        raise RefineryApiError(
+            f'Failed to retrieve Drupal API location data \
+            for {location}: {e}')
+    except (JSONDecodeError, KeyError) as e:
+        raise RefineryApiError(
+            f'Failed to parse Drupal API response: \
+                {type(e)} {e}')
+
+
+def parse_address(address_data):
+    return {
+        'line1': address_data.get('address_line1', ''),
+        'city': address_data.get('locality', ''),
+        'state': address_data.get('administrative_area', ''),
+        'postal_code': address_data.get('postal_code', '')
+    }
+
+def datetime_from_hours_string(base_date:datetime, hours_string: str):
+    # given a base date, turn a string like 10 AM into a datetime
+    hour_and_time_of_day = hours_string.split(' ')
+    hour = int(hour_and_time_of_day[0])
+    time_of_day = hour_and_time_of_day[1]
+    if time_of_day.lower() == 'pm' and hour != 12:
+        hour += 12
+    if time_of_day.lower() == 'am' and hour == 12:
+        hour = 0
+    return base_date.replace(hour=hour).isoformat()
+
+def parse_hours(current_date: datetime, date):
+    # parse hours in the form
+    # {
+    #  "day": "Tuesday",
+    #  "date": "8/26",
+    #  "hours": "10 AM–8 PM"
+    # },
+    # to the expected return format
+    # {
+    #   "day": "Tuesday",
+    #   "startTime": "2025-08-26T10:00:00+00:00",
+    #   "endTime": "2025-08-26T20:00:00+00:00",
+    #   "today": true
+    # },
+
+    # get a datetime for this weekday based off today's weekday
+    weekday = date.get('day')
+    current_weekday = current_date.weekday()
+    weekday_index = INTEGER_DAYS.get(weekday.upper())
+    if weekday_index >= current_weekday:
+        weekday_offset = weekday_index - current_date.weekday()
+    else:
+        weekday_offset = 7 - current_weekday + weekday_index
+
+    base_date = current_date + datetime.timedelta(days=weekday_offset)
+
+    hours = {
+        'day': weekday
+    }
+
+    # get start and close times from the "10 AM-8 PM" hours string
+    if date.get('hours').lower() == 'closed':
+        hours['startTime'] = None
+        hours['endTime'] = None
+    else:
+        start_and_end = date.get('hours').split('–')
+        hours['startTime'] = datetime_from_hours_string(base_date, start_and_end[0])
+        hours['endTime'] = datetime_from_hours_string(base_date, start_and_end[1])
+    if weekday_offset == 0:
+        hours['today'] = True
+    return hours
+
+
+# given an array of fields and a location
+#  code, return an dict populated
+# by those fields for that location code.
+def get_location_data(code, fields):
+    data = {}
+    location_data = check_cache_and_or_fetch_data(code)
+    if location_data is None:
+        return None
+    if 'location' in fields:
+        data['location'] = parse_address(location_data.get('field_as_address', {}))
+    if 'hours' in fields:
+        # If upcoming_hours exists, use that, otherwise use regular_hours
+        location_hours = location_data.get('location_hours')
+        upcoming_hours = location_hours.get('upcoming_hours') if location_hours.get('upcoming_hours') else location_hours.get('regular_hours')
+        data['hours'] = []
+        current_date = datetime.datetime.now().astimezone().replace(hour=0, minute=0, second=0, microsecond=0)
+        today_index = 0
+        for index in range(len(upcoming_hours)):
+            date = upcoming_hours[index]
+            parsed_hours = parse_hours(current_date, date)
+            data['hours'].append(parsed_hours)
+            if parsed_hours.get('today'):
+                today_index = index
+        # determine the next business day
+        for offset in range(1, 7):
+            relative_offset = (today_index + offset) % 7
+            if data['hours'][relative_offset].get('startTime'):
+                data['hours'][relative_offset]['nextBusinessDay'] = True
+                break
+
+    return data
+
+
+def check_cache_and_or_fetch_data(code):
+    location_data = get_location_by_code(code)
+    if not location_data:
+        return None
+    delta = datetime.datetime.now(tz=datetime.timezone.utc) - parse(location_data.get('changed'))
+    if delta.seconds > 3600:
+        get_location_by_code.cache_clear()
+        logger.info('Refreshing Drupal API data for location: ' + code)
+        location_data = get_location_by_code(code)
+    return location_data

--- a/lib/location_lookup.py
+++ b/lib/location_lookup.py
@@ -9,6 +9,7 @@ import lib.nypl_core
 from lib.logger import GlobalLogger
 from lib.errors import MissingEnvVar
 from lib.refinery_api import get_refinery_data
+from lib.location_api import get_location_data
 
 
 @cache
@@ -65,7 +66,7 @@ def build_location_info(location_code, fields):
             # TODO: remove dependency on code property in DFE
             code = location_code
             url = s3_url
-    refinery_data = get_refinery_data(location_code, fields)
+    refinery_data = get_location_data(location_code, fields)
     # original implementation of this code returned an array of multiple codes
     # which the front end would then filter through. We now only return one,
     # correct location, but it has to be in an array due to original contract.

--- a/lib/location_lookup.py
+++ b/lib/location_lookup.py
@@ -8,7 +8,6 @@ from nypl_py_utils.classes.s3_client import S3Client
 import lib.nypl_core
 from lib.logger import GlobalLogger
 from lib.errors import MissingEnvVar
-from lib.refinery_api import get_refinery_data
 from lib.location_api import get_location_data
 
 

--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ def handler(event, context):
             return create_response(400,
                                    'No location codes provided')
         except Exception as e:
-            logger.warn(f'Received error in fetch_locations_and_respond. \
-Message: {e}')
+            logger.error(f'Received error in fetch_locations_and_respond. \
+Message: {e}', e)
             return create_response(500,
                                    f'Failed to fetch locations \
 {location_codes} by code')

--- a/test/data/drupal_responses/ma.json
+++ b/test/data/drupal_responses/ma.json
@@ -1,0 +1,1075 @@
+{
+"jsonapi": {
+"version": "1.0",
+"meta": {
+"links": {
+"self": {
+"href": "http://jsonapi.org/format/1.0/"
+}
+}
+}
+},
+"data": [
+{
+"type": "node--library",
+"id": "50b5b1c6-e01f-4728-befb-90578bb0d1d4",
+"links": {},
+"attributes": {
+"drupal_internal__nid": 4,
+"drupal_internal__vid": 123031,
+"langcode": "en",
+"revision_timestamp": "2025-08-22T14:20:17+00:00",
+"status": true,
+"title": "Stephen A. Schwarzman Building",
+"created": "2019-08-14T16:11:32+00:00",
+"changed": "2025-08-22T14:20:17+00:00",
+"promote": false,
+"sticky": false,
+"default_langcode": true,
+"revision_translation_affected": true,
+"moderation_state": null,
+"metatag": [
+{
+"tag": "meta",
+"attributes": {
+"name": "title",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "description",
+"content": "The Stephen A. Schwarzman Building is part of The New York Public Library, which consists of four major research libraries and 88 branch libraries located in the Bronx, Manhattan, and Staten Island. Often referred to as the \"main branch,\" the Beaux-Arts landmark building on Fifth Avenue and 42nd Street houses outstanding research collections in the humanities and social sciences. The Stephen A. Schwarzman Building is currently undergoing a renovation. Learn more."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "keywords",
+"content": "NYPL, The New York Public Library, Manhattan, Bronx, Staten Island"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "geo.placename",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "geo.region",
+"content": "US-NY"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "geo.position",
+"content": "40.7534887, -73.9808774"
+}
+},
+{
+"tag": "link",
+"attributes": {
+"rel": "canonical",
+"href": "https://www.nypl.org/locations/schwarzman"
+}
+},
+{
+"tag": "link",
+"attributes": {
+"rel": "image_src",
+"href": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_2400/public/2020-07/exterior_sasb.jpg?h=def3cf70&itok=7n-f3fHg"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "generator",
+"content": "nypl-v1.0"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "rights",
+"content": "© 2025 The New York Public Library"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:site_name",
+"content": "The New York Public Library"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:url",
+"content": "https://drupal.nypl.org/locations/schwarzman"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:title",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:description",
+"content": "The Stephen A. Schwarzman Building is part of The New York Public Library, which consists of four major research libraries and 88 branch libraries located in the Bronx, Manhattan, and Staten Island. Often referred to as the \"main branch,\" the Beaux-Arts landmark building on Fifth Avenue and 42nd Street houses outstanding research collections in the humanities and social sciences. The Stephen A. Schwarzman Building is currently undergoing a renovation. Learn more."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:image",
+"content": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_2400/public/2020-07/exterior_sasb.jpg?h=def3cf70&itok=7n-f3fHg"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:image:alt",
+"content": "Exterior view of the Stephen A. Schwarzman Building."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "place:location:longitude",
+"content": "-73.9808774"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "place:location:latitude",
+"content": "40.7534887"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:street_address",
+"content": "Fifth Avenue and 42nd Street"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:locality",
+"content": "New York"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:region",
+"content": "NY"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:postal_code",
+"content": "10018"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:country_name",
+"content": "US"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:phone_number",
+"content": "9172756975"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:card",
+"content": "summary_large_image"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:site",
+"content": "@nypl"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:title",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:description",
+"content": "The Stephen A. Schwarzman Building is part of The New York Public Library, which consists of four major research libraries and 88 branch libraries located in the Bronx, Manhattan, and Staten Island. Often referred to as the \"main branch,\" the Beaux-Arts landmark building on Fifth Avenue and 42nd Street houses outstanding research collections in the humanities and social sciences. The Stephen A. Schwarzman Building is currently undergoing a renovation. Learn more."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:image:alt",
+"content": "Exterior view of the Stephen A. Schwarzman Building."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:image",
+"content": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_2400/public/2020-07/exterior_sasb.jpg?h=def3cf70&itok=7n-f3fHg"
+}
+}
+],
+"path": {
+"alias": "/locations/schwarzman",
+"pid": 356,
+"langcode": "en"
+},
+"rh_action": "bundle_default",
+"rh_redirect": null,
+"rh_redirect_response": 301,
+"rh_redirect_fallback_action": "bundle_default",
+"publish_on": null,
+"unpublish_on": null,
+"publish_state": null,
+"unpublish_state": null,
+"content_translation_source": "und",
+"content_translation_outdated": false,
+"field_geos_coordinates": {
+"lat": 40.7534887,
+"lng": -73.9808774,
+"data": [],
+"value": "40.7534887, -73.9808774"
+},
+"field_lns_link": null,
+"field_lts_wheelchair_access": "full",
+"field_ts_cross_street": null,
+"field_ts_library_type": "research",
+"field_ts_location_code": "ma",
+"field_as_address": {
+"langcode": "en",
+"country_code": "US",
+"administrative_area": "NY",
+"locality": "New York",
+"postal_code": "10018",
+"address_line1": "Fifth Avenue and 42nd Street",
+"address_line3": ""
+},
+"field_bs_display_visit_cta": true,
+"field_es_email": null,
+"field_im_legacy_term_ids": [
+36,
+8196,
+246,
+198,
+173,
+177,
+394,
+444,
+199,
+176,
+175,
+443,
+447,
+688,
+446,
+445,
+621,
+8002,
+184,
+850,
+1035,
+202,
+845,
+165,
+182,
+1041,
+197,
+195,
+178,
+1040,
+179,
+851,
+172,
+180,
+847,
+7603,
+711,
+2800,
+848,
+192,
+849,
+8192,
+7590,
+1030,
+1031,
+846,
+174,
+181,
+183,
+8227
+],
+"field_lnm_library_guides": [],
+"field_lns_appointment_form": null,
+"field_lns_contact_link": null,
+"field_lns_social_facebook": null,
+"field_lns_social_instagram": null,
+"field_lns_social_twitter": null,
+"field_ohs_hours": [
+{
+"day": 1,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+},
+{
+"day": 2,
+"all_day": false,
+"starthours": 1000,
+"endhours": 2000,
+"comment": ""
+},
+{
+"day": 3,
+"all_day": false,
+"starthours": 1000,
+"endhours": 2000,
+"comment": ""
+},
+{
+"day": 4,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+},
+{
+"day": 5,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+},
+{
+"day": 6,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+}
+],
+"field_tels_fax": null,
+"field_tels_phone": "9172756975",
+"field_tels_tty": null,
+"field_tfls_accessibility_details": {
+"value": "<p>The New York Public Library strives to ensure that everyone has access to the full range of information, services, and programs that are offered at the Library.&nbsp;<a href=\"https://www.nypl.org/accessibility\">Learn more.</a></p>\r\n\r\n<p>All public service units of the Stephen A. Schwarzman Building are wheelchair accessible. A ramp entrance to the building is located at 42nd Street, and a street-level accessible entrance is available at 40th Street. All levels of the building are accessible by an elevator at the north end of the building.</p>\r\n\r\n<p>If you require an additional accommodation on site, please speak to a staff member. For more information or for an accommodation, please email accessibility@nypl.org. To learn more about the accessibility of NYPL websites and mobile applications, see our&nbsp;<a href=\"https://www.nypl.org/policies/web-mobile-accessibility\">Web &amp; Mobile Accessibility Policy</a>.</p>\r\n\r\n<p><strong>Please Note:</strong></p>\r\n\r\n<ul>\r\n\t<li>As part of the Library's Midtown Renovation, we are in the process of upgrading, renovating, and adding more public space to the Schwarzman Building to prepare this historic library for future research, exhibitions, and programs. Currently, we are working on upgrades to the building’s cooling tower and HVAC system, as well as improvements to building circulation and flow with the addition of a new elevator and staircase. We remain focused on limiting the impact of this work on public service, but we do ask for patience and understanding in instances of noise or any other disruption during your visit.<br />\r\n\t&nbsp;</li>\r\n\t<li>Due to new Library policy, e-bikes, e-scooters, and electronic transportation devices are not permitted inside any NYPL location.&nbsp;This does not apply to mobility aids.</li>\r\n</ul>\r\n",
+"format": "body_text",
+"processed": "<p>The New York Public Library strives to ensure that everyone has access to the full range of information, services, and programs that are offered at the Library.&nbsp;<a href=\"https://www.nypl.org/accessibility\" rel=\"nofollow\">Learn more.</a></p>\n<p>All public service units of the Stephen A. Schwarzman Building are wheelchair accessible. A ramp entrance to the building is located at 42nd Street, and a street-level accessible entrance is available at 40th Street. All levels of the building are accessible by an elevator at the north end of the building.</p>\n<p>If you require an additional accommodation on site, please speak to a staff member. For more information or for an accommodation, please email <a href=\"mailto:accessibility@nypl.org\">accessibility@nypl.org</a>. To learn more about the accessibility of NYPL websites and mobile applications, see our&nbsp;<a href=\"https://www.nypl.org/policies/web-mobile-accessibility\" rel=\"nofollow\">Web &amp; Mobile Accessibility Policy</a>.</p>\n<p><strong>Please Note:</strong></p>\n<ul>\n<li>As part of the Library's Midtown Renovation, we are in the process of upgrading, renovating, and adding more public space to the Schwarzman Building to prepare this historic library for future research, exhibitions, and programs. Currently, we are working on upgrades to the building’s cooling tower and HVAC system, as well as improvements to building circulation and flow with the addition of a new elevator and staircase. We remain focused on limiting the impact of this work on public service, but we do ask for patience and understanding in instances of noise or any other disruption during your visit.<br><br>\n\t&nbsp;</li>\n<li>Due to new Library policy, e-bikes, e-scooters, and electronic transportation devices are not permitted inside any NYPL location.&nbsp;This does not apply to mobility aids.</li>\n</ul>\n"
+},
+"field_tm_synonyms": [],
+"field_ts_accessibility_note": "Enter the building via the main entrance on Fifth Avenue, or the accessible entrances at 40th Street and 42nd Street.",
+"field_ts_slug": "schwarzman",
+"field_ts_sponsors_label": null,
+"location_hours": {
+"regular_hours": [
+{
+"day": "Monday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Tuesday",
+"hours": "10 AM–8 PM"
+},
+{
+"day": "Wednesday",
+"hours": "10 AM–8 PM"
+},
+{
+"day": "Thursday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Friday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Saturday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Sunday",
+"hours": "Closed"
+}
+],
+"upcoming_hours": [
+{
+"day": "Monday",
+"date": "9/1",
+"hours": "Closed"
+},
+{
+"day": "Tuesday",
+"date": "8/26",
+"hours": "10 AM–8 PM"
+},
+{
+"day": "Wednesday",
+"date": "8/27",
+"hours": "10 AM–8 PM"
+},
+{
+"day": "Thursday",
+"date": "8/28",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Friday",
+"date": "8/29",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Saturday",
+"date": "8/30",
+"hours": "Closed"
+},
+{
+"day": "Sunday",
+"date": "8/31",
+"hours": "Closed"
+}
+],
+"is_temporarily_closed": false,
+"hours_today": {
+"text": "Open today",
+"time": "10 AM–8 PM"
+}
+},
+"alerts": [
+{
+"id": 1662,
+"message": "<p>Please note that&nbsp;the Stephen A. Schwarzman Building will be closed on Sundays throughout the summer. Regular Sunday hours will resume on Sunday, September 7.&nbsp;</p>",
+"publish_start": "2025-06-30T04:00:00",
+"publish_end": "2025-09-01T13:00:00"
+},
+{
+"id": 2848,
+"message": "<p>Please note that the Polonsky Exhibition of The New York Public Library's Treasures will open at 12:00 PM on Thursday, August 28. We apologize for the inconvenience.</p>",
+"publish_start": "2025-08-23T12:00:00",
+"publish_end": "2025-08-28T16:00:00"
+}
+],
+"closings": null,
+"explore": {
+"view_display_title": "Explore Divisions & Centers",
+"view_machine_name": "block_library_divisions_centers",
+"items": [
+{
+"id": "f27e87bc-a7ed-44bb-8c87-a2237a4e63f1",
+"title": "Carl H. Pforzheimer Collection of Shelley and His Circle",
+"slug": "/locations/schwarzman/pforzheimer-collection-shelley-and-his-circle",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_pforzheimer_I45A8082_0.jpg?h=5bf6543a&itok=tTN8cWFg",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "575a664c-dc12-481a-b49b-0aa432bca819",
+"title": "Dorot Jewish Division",
+"slug": "/locations/schwarzman/jewish-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_jewish_I45A7970.jpg?h=5bf6543a&itok=GF1CZviq",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "First Floor"
+},
+{
+"id": "7053a199-5766-4cb8-9a4a-cd9ccdf249d3",
+"title": "General Research Division",
+"slug": "/locations/schwarzman/general-research-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/GeneralResearch_Preview.jpg?h=5bf6543a&itok=0gnSKC6c",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "Third Floor"
+},
+{
+"id": "877db794-1579-48bd-8715-6332ddb1ef48",
+"title": "Henry W. and Albert A. Berg Collection of English and American Literature",
+"slug": "/locations/schwarzman/berg-collection-english-and-american-literature",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_berg_I45A8437.jpg?h=5bf6543a&itok=Pz8SWUbC",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "81f53447-74e8-4382-8d76-327ffe7ea3be",
+"title": "Irma and Paul Milstein Division of United States History, Local History and Genealogy",
+"slug": "/locations/schwarzman/milstein",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/USHistory_Preview.jpg?h=5bf6543a&itok=xd-UG8em",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "First Floor"
+},
+{
+"id": "fd091eeb-e313-4719-b201-492d4ccd196f",
+"title": "Lionel Pincus and Princess Firyal Map Division",
+"slug": "/locations/schwarzman/map-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_map_1049.jpg?h=5bf6543a&itok=7D_7cqRu",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "First Floor"
+},
+{
+"id": "da24b3e5-db41-4ad2-a518-b5ef878c9f0c",
+"title": "Manuscripts and Archives Division",
+"slug": "/locations/schwarzman/manuscripts-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/Manuscripts_Preview_0.jpg?h=5bf6543a&itok=mmuTEz2B",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "5345f4a3-f2d8-4f1f-868f-2a5689bc364a",
+"title": "Rare Book Division",
+"slug": "/locations/schwarzman/rare-books-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_rarebooks_I45A8003.jpg?h=5bf6543a&itok=g95Q5q7J",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "d9067e9b-3cc7-477e-88ab-7d81d92b3f37",
+"title": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs",
+"slug": "/locations/schwarzman/wallach-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/APP_Preview.jpg?h=5bf6543a&itok=VTXuh1As",
+"summary": null,
+"division_hours": "10 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "c5716a12-bd5d-457a-af9c-d1a0305ffebf",
+"title": "Vartan Gregorian Center for Research in the Humanities",
+"slug": "/locations/schwarzman/center-research-humanities",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2023-11/Gregorian_Center_Noma_1000x500.jpeg?h=5dabf909&itok=4Tn5A_DA",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "Second Floor"
+},
+{
+"id": "ab075f99-2ff1-4bfb-b580-e92860bbae33",
+"title": "Visitor Center",
+"slug": "/locations/schwarzman/visitor-center",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2023-06/SASB_2023_05_01_Welcome_Center-00351.jpg?h=56d0ca2e&itok=z7Tqt0nW",
+"summary": "<p>We look forward to welcoming you to The New York Public Library. Get the most out of your visit with these helpful tips, including what to bring with you, how to get here, accessibility information, exhibition tours, and more.</p>\n",
+"division_hours": "10 AM–8 PM",
+"floor": "First Floor"
+}
+]
+}
+},
+"relationships": {
+"node_type": {
+"data": {
+"type": "node_type--node_type",
+"id": "cf7f123c-64c1-4fc7-93d4-bff46b7f900b",
+"meta": {
+"drupal_internal__target_id": "library"
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/node_type?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/node_type?resourceVersion=id%3A123031"
+}
+}
+},
+"revision_uid": {
+"data": {
+"type": "user--user",
+"id": "e9ea1163-2137-44cf-a80a-730f302dada6",
+"meta": {
+"drupal_internal__target_id": 1170
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/revision_uid?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/revision_uid?resourceVersion=id%3A123031"
+}
+}
+},
+"uid": {
+"data": {
+"type": "user--user",
+"id": "bf11eb62-42f9-48b7-8ba5-db5b68a6b38d",
+"meta": {
+"drupal_internal__target_id": 1
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/uid?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/uid?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_optional_announcements": {
+"data": [
+{
+"type": "paragraph--text_with_image",
+"id": "7170e705-bd2d-46f9-b27f-c7922acda639",
+"meta": {
+"target_revision_id": 1033847,
+"drupal_internal__target_id": 80257
+}
+},
+{
+"type": "paragraph--text_with_image",
+"id": "f4cd3b48-fe44-4d60-aac9-a74670792d37",
+"meta": {
+"target_revision_id": 1033848,
+"drupal_internal__target_id": 76229
+}
+},
+{
+"type": "paragraph--text_with_image",
+"id": "b11525c0-1eca-4af9-9496-35d36aae1c36",
+"meta": {
+"target_revision_id": 1033849,
+"drupal_internal__target_id": 7257
+}
+}
+],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_optional_announcements?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_optional_announcements?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_staff_picks": {
+"data": [],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_staff_picks?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_staff_picks?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_explore_tab_intro": {
+"data": {
+"type": "paragraph--first_paragraph",
+"id": "79622794-08fc-45f6-ac61-3a9b60630945",
+"meta": {
+"target_revision_id": 1033807,
+"drupal_internal__target_id": 3159
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_explore_tab_intro?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_explore_tab_intro?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_explore_2": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "19f6dff7-4541-4311-a8b3-0493c29a1946",
+"meta": {
+"target_revision_id": 1033820,
+"drupal_internal__target_id": 3135
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_explore_2?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_explore_2?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_visit_1": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "332f8cca-855c-425c-ada1-0b15a49143e1",
+"meta": {
+"target_revision_id": 1033825,
+"drupal_internal__target_id": 3150
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_visit_1?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_visit_1?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_visit_2": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "306655ec-1bff-4166-a7fd-f8d9fb98a0f1",
+"meta": {
+"target_revision_id": 1033830,
+"drupal_internal__target_id": 3146
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_visit_2?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_visit_2?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_logo": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_logo?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_logo?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_promo_space": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_promo_space?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_promo_space?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_feature_managers": {
+"data": [],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_feature_managers?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_feature_managers?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_library_amenities": {
+"data": [
+{
+"type": "paragraph--library_amenity",
+"id": "4d42ffcc-fe05-4a05-8719-de8e41814e69",
+"meta": {
+"target_revision_id": 1033831,
+"drupal_internal__target_id": 1080
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "f592e21d-5579-4be0-b545-52bfee0caeb7",
+"meta": {
+"target_revision_id": 1033832,
+"drupal_internal__target_id": 1081
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "6b28e81f-e13d-4d81-9eef-b3008da87a93",
+"meta": {
+"target_revision_id": 1033833,
+"drupal_internal__target_id": 1082
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "209844c0-e696-49c3-b913-d1f2178142e8",
+"meta": {
+"target_revision_id": 1033834,
+"drupal_internal__target_id": 1083
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "32f0844f-540a-4661-b59a-8503d2ecc960",
+"meta": {
+"target_revision_id": 1033835,
+"drupal_internal__target_id": 1084
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "7f653187-29e2-4afb-92d2-82813de85a01",
+"meta": {
+"target_revision_id": 1033836,
+"drupal_internal__target_id": 1085
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "9e7c3cf9-ee81-470f-967d-22e2902957dc",
+"meta": {
+"target_revision_id": 1033837,
+"drupal_internal__target_id": 1086
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "ba50412a-994b-4533-8961-cd15a0de7025",
+"meta": {
+"target_revision_id": 1033838,
+"drupal_internal__target_id": 1087
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "5262dacc-838e-44bf-b185-76b974da6701",
+"meta": {
+"target_revision_id": 1033839,
+"drupal_internal__target_id": 1088
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "ad84de62-b397-4abd-9327-886042b99155",
+"meta": {
+"target_revision_id": 1033840,
+"drupal_internal__target_id": 1089
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "54841e76-7c3d-4e44-b73a-c81129c8bbbc",
+"meta": {
+"target_revision_id": 1033841,
+"drupal_internal__target_id": 1090
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "99ad427b-3856-447a-bb29-986c90bd069b",
+"meta": {
+"target_revision_id": 1033842,
+"drupal_internal__target_id": 1092
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "34dadfc6-93f7-4f3b-99aa-0ed8e34335ec",
+"meta": {
+"target_revision_id": 1033843,
+"drupal_internal__target_id": 1093
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "8cb46c2f-d9a1-4489-90db-fffa9b6440f1",
+"meta": {
+"target_revision_id": 1033844,
+"drupal_internal__target_id": 1094
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "463169cf-de3e-4c6c-a42e-806027c6e3bd",
+"meta": {
+"target_revision_id": 1033845,
+"drupal_internal__target_id": 1095
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "2b36e7a5-04a2-44bf-8064-2aed640bec03",
+"meta": {
+"target_revision_id": 1033846,
+"drupal_internal__target_id": 1096
+}
+}
+],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_library_amenities?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_library_amenities?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_sponsors": {
+"data": [],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_sponsors?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_sponsors?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_about_the_library": {
+"data": {
+"type": "paragraph--text_with_image",
+"id": "026db135-1824-412e-a44f-7bb86c956af4",
+"meta": {
+"target_revision_id": 1033806,
+"drupal_internal__target_id": 2682
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_about_the_library?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_about_the_library?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_additional_info": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_additional_info?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_additional_info?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_hero_image": {
+"data": {
+"type": "media--decorative_image",
+"id": "41acd9e0-7120-47ef-a36c-b11e490e66be",
+"meta": {
+"drupal_internal__target_id": 2441
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_hero_image?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_hero_image?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_interior_media_image": {
+"data": {
+"type": "media--image",
+"id": "283fc99e-4ee9-4df9-8c36-d4f9e9943ceb",
+"meta": {
+"drupal_internal__target_id": 2073
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_interior_media_image?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_interior_media_image?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_explore_1": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "fff569ac-92ea-494d-8af8-49cecdbd0d16",
+"meta": {
+"target_revision_id": 1033814,
+"drupal_internal__target_id": 3130
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_explore_1?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_explore_1?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_media_image": {
+"data": {
+"type": "media--image",
+"id": "ca19ec42-0f74-4371-b48c-68bdc01aea53",
+"meta": {
+"drupal_internal__target_id": 2074
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_media_image?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_media_image?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_read_tab_intro": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_read_tab_intro?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_read_tab_intro?resourceVersion=id%3A123031"
+}
+}
+},
+"field_first_paragraph": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_first_paragraph?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_first_paragraph?resourceVersion=id%3A123031"
+}
+}
+}
+}
+}
+],
+"meta": {
+"count": 1
+},
+"links": {
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library?filter%5Bfield_ts_location_code%5D=ma"
+}
+}
+}

--- a/test/data/drupal_responses/ma_regular_hours.json
+++ b/test/data/drupal_responses/ma_regular_hours.json
@@ -1,0 +1,1039 @@
+{
+"jsonapi": {
+"version": "1.0",
+"meta": {
+"links": {
+"self": {
+"href": "http://jsonapi.org/format/1.0/"
+}
+}
+}
+},
+"data": [
+{
+"type": "node--library",
+"id": "50b5b1c6-e01f-4728-befb-90578bb0d1d4",
+"links": {},
+"attributes": {
+"drupal_internal__nid": 4,
+"drupal_internal__vid": 123031,
+"langcode": "en",
+"revision_timestamp": "2025-08-22T14:20:17+00:00",
+"status": true,
+"title": "Stephen A. Schwarzman Building",
+"created": "2019-08-14T16:11:32+00:00",
+"changed": "2025-08-22T14:20:17+00:00",
+"promote": false,
+"sticky": false,
+"default_langcode": true,
+"revision_translation_affected": true,
+"moderation_state": null,
+"metatag": [
+{
+"tag": "meta",
+"attributes": {
+"name": "title",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "description",
+"content": "The Stephen A. Schwarzman Building is part of The New York Public Library, which consists of four major research libraries and 88 branch libraries located in the Bronx, Manhattan, and Staten Island. Often referred to as the \"main branch,\" the Beaux-Arts landmark building on Fifth Avenue and 42nd Street houses outstanding research collections in the humanities and social sciences. The Stephen A. Schwarzman Building is currently undergoing a renovation. Learn more."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "keywords",
+"content": "NYPL, The New York Public Library, Manhattan, Bronx, Staten Island"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "geo.placename",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "geo.region",
+"content": "US-NY"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "geo.position",
+"content": "40.7534887, -73.9808774"
+}
+},
+{
+"tag": "link",
+"attributes": {
+"rel": "canonical",
+"href": "https://www.nypl.org/locations/schwarzman"
+}
+},
+{
+"tag": "link",
+"attributes": {
+"rel": "image_src",
+"href": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_2400/public/2020-07/exterior_sasb.jpg?h=def3cf70&itok=7n-f3fHg"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "generator",
+"content": "nypl-v1.0"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "rights",
+"content": "© 2025 The New York Public Library"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:site_name",
+"content": "The New York Public Library"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:url",
+"content": "https://drupal.nypl.org/locations/schwarzman"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:title",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:description",
+"content": "The Stephen A. Schwarzman Building is part of The New York Public Library, which consists of four major research libraries and 88 branch libraries located in the Bronx, Manhattan, and Staten Island. Often referred to as the \"main branch,\" the Beaux-Arts landmark building on Fifth Avenue and 42nd Street houses outstanding research collections in the humanities and social sciences. The Stephen A. Schwarzman Building is currently undergoing a renovation. Learn more."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:image",
+"content": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_2400/public/2020-07/exterior_sasb.jpg?h=def3cf70&itok=7n-f3fHg"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:image:alt",
+"content": "Exterior view of the Stephen A. Schwarzman Building."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "place:location:longitude",
+"content": "-73.9808774"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "place:location:latitude",
+"content": "40.7534887"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:street_address",
+"content": "Fifth Avenue and 42nd Street"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:locality",
+"content": "New York"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:region",
+"content": "NY"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:postal_code",
+"content": "10018"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:country_name",
+"content": "US"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"property": "og:phone_number",
+"content": "9172756975"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:card",
+"content": "summary_large_image"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:site",
+"content": "@nypl"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:title",
+"content": "Stephen A. Schwarzman Building"
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:description",
+"content": "The Stephen A. Schwarzman Building is part of The New York Public Library, which consists of four major research libraries and 88 branch libraries located in the Bronx, Manhattan, and Staten Island. Often referred to as the \"main branch,\" the Beaux-Arts landmark building on Fifth Avenue and 42nd Street houses outstanding research collections in the humanities and social sciences. The Stephen A. Schwarzman Building is currently undergoing a renovation. Learn more."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:image:alt",
+"content": "Exterior view of the Stephen A. Schwarzman Building."
+}
+},
+{
+"tag": "meta",
+"attributes": {
+"name": "twitter:image",
+"content": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_2400/public/2020-07/exterior_sasb.jpg?h=def3cf70&itok=7n-f3fHg"
+}
+}
+],
+"path": {
+"alias": "/locations/schwarzman",
+"pid": 356,
+"langcode": "en"
+},
+"rh_action": "bundle_default",
+"rh_redirect": null,
+"rh_redirect_response": 301,
+"rh_redirect_fallback_action": "bundle_default",
+"publish_on": null,
+"unpublish_on": null,
+"publish_state": null,
+"unpublish_state": null,
+"content_translation_source": "und",
+"content_translation_outdated": false,
+"field_geos_coordinates": {
+"lat": 40.7534887,
+"lng": -73.9808774,
+"data": [],
+"value": "40.7534887, -73.9808774"
+},
+"field_lns_link": null,
+"field_lts_wheelchair_access": "full",
+"field_ts_cross_street": null,
+"field_ts_library_type": "research",
+"field_ts_location_code": "ma",
+"field_as_address": {
+"langcode": "en",
+"country_code": "US",
+"administrative_area": "NY",
+"locality": "New York",
+"postal_code": "10018",
+"address_line1": "Fifth Avenue and 42nd Street",
+"address_line3": ""
+},
+"field_bs_display_visit_cta": true,
+"field_es_email": null,
+"field_im_legacy_term_ids": [
+36,
+8196,
+246,
+198,
+173,
+177,
+394,
+444,
+199,
+176,
+175,
+443,
+447,
+688,
+446,
+445,
+621,
+8002,
+184,
+850,
+1035,
+202,
+845,
+165,
+182,
+1041,
+197,
+195,
+178,
+1040,
+179,
+851,
+172,
+180,
+847,
+7603,
+711,
+2800,
+848,
+192,
+849,
+8192,
+7590,
+1030,
+1031,
+846,
+174,
+181,
+183,
+8227
+],
+"field_lnm_library_guides": [],
+"field_lns_appointment_form": null,
+"field_lns_contact_link": null,
+"field_lns_social_facebook": null,
+"field_lns_social_instagram": null,
+"field_lns_social_twitter": null,
+"field_ohs_hours": [
+{
+"day": 1,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+},
+{
+"day": 2,
+"all_day": false,
+"starthours": 1000,
+"endhours": 2000,
+"comment": ""
+},
+{
+"day": 3,
+"all_day": false,
+"starthours": 1000,
+"endhours": 2000,
+"comment": ""
+},
+{
+"day": 4,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+},
+{
+"day": 5,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+},
+{
+"day": 6,
+"all_day": false,
+"starthours": 1000,
+"endhours": 1800,
+"comment": ""
+}
+],
+"field_tels_fax": null,
+"field_tels_phone": "9172756975",
+"field_tels_tty": null,
+"field_tfls_accessibility_details": {
+"value": "<p>The New York Public Library strives to ensure that everyone has access to the full range of information, services, and programs that are offered at the Library.&nbsp;<a href=\"https://www.nypl.org/accessibility\">Learn more.</a></p>\r\n\r\n<p>All public service units of the Stephen A. Schwarzman Building are wheelchair accessible. A ramp entrance to the building is located at 42nd Street, and a street-level accessible entrance is available at 40th Street. All levels of the building are accessible by an elevator at the north end of the building.</p>\r\n\r\n<p>If you require an additional accommodation on site, please speak to a staff member. For more information or for an accommodation, please email accessibility@nypl.org. To learn more about the accessibility of NYPL websites and mobile applications, see our&nbsp;<a href=\"https://www.nypl.org/policies/web-mobile-accessibility\">Web &amp; Mobile Accessibility Policy</a>.</p>\r\n\r\n<p><strong>Please Note:</strong></p>\r\n\r\n<ul>\r\n\t<li>As part of the Library's Midtown Renovation, we are in the process of upgrading, renovating, and adding more public space to the Schwarzman Building to prepare this historic library for future research, exhibitions, and programs. Currently, we are working on upgrades to the building’s cooling tower and HVAC system, as well as improvements to building circulation and flow with the addition of a new elevator and staircase. We remain focused on limiting the impact of this work on public service, but we do ask for patience and understanding in instances of noise or any other disruption during your visit.<br />\r\n\t&nbsp;</li>\r\n\t<li>Due to new Library policy, e-bikes, e-scooters, and electronic transportation devices are not permitted inside any NYPL location.&nbsp;This does not apply to mobility aids.</li>\r\n</ul>\r\n",
+"format": "body_text",
+"processed": "<p>The New York Public Library strives to ensure that everyone has access to the full range of information, services, and programs that are offered at the Library.&nbsp;<a href=\"https://www.nypl.org/accessibility\" rel=\"nofollow\">Learn more.</a></p>\n<p>All public service units of the Stephen A. Schwarzman Building are wheelchair accessible. A ramp entrance to the building is located at 42nd Street, and a street-level accessible entrance is available at 40th Street. All levels of the building are accessible by an elevator at the north end of the building.</p>\n<p>If you require an additional accommodation on site, please speak to a staff member. For more information or for an accommodation, please email <a href=\"mailto:accessibility@nypl.org\">accessibility@nypl.org</a>. To learn more about the accessibility of NYPL websites and mobile applications, see our&nbsp;<a href=\"https://www.nypl.org/policies/web-mobile-accessibility\" rel=\"nofollow\">Web &amp; Mobile Accessibility Policy</a>.</p>\n<p><strong>Please Note:</strong></p>\n<ul>\n<li>As part of the Library's Midtown Renovation, we are in the process of upgrading, renovating, and adding more public space to the Schwarzman Building to prepare this historic library for future research, exhibitions, and programs. Currently, we are working on upgrades to the building’s cooling tower and HVAC system, as well as improvements to building circulation and flow with the addition of a new elevator and staircase. We remain focused on limiting the impact of this work on public service, but we do ask for patience and understanding in instances of noise or any other disruption during your visit.<br><br>\n\t&nbsp;</li>\n<li>Due to new Library policy, e-bikes, e-scooters, and electronic transportation devices are not permitted inside any NYPL location.&nbsp;This does not apply to mobility aids.</li>\n</ul>\n"
+},
+"field_tm_synonyms": [],
+"field_ts_accessibility_note": "Enter the building via the main entrance on Fifth Avenue, or the accessible entrances at 40th Street and 42nd Street.",
+"field_ts_slug": "schwarzman",
+"field_ts_sponsors_label": null,
+"location_hours": {
+"regular_hours": [
+{
+"day": "Monday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Tuesday",
+"hours": "10 AM–8 PM"
+},
+{
+"day": "Wednesday",
+"hours": "10 AM–8 PM"
+},
+{
+"day": "Thursday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Friday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Saturday",
+"hours": "10 AM–6 PM"
+},
+{
+"day": "Sunday",
+"hours": "Closed"
+}
+],
+"upcoming_hours": null,
+"is_temporarily_closed": false,
+"hours_today": {
+"text": "Open today",
+"time": "10 AM–8 PM"
+}
+},
+"alerts": [
+{
+"id": 1662,
+"message": "<p>Please note that&nbsp;the Stephen A. Schwarzman Building will be closed on Sundays throughout the summer. Regular Sunday hours will resume on Sunday, September 7.&nbsp;</p>",
+"publish_start": "2025-06-30T04:00:00",
+"publish_end": "2025-09-01T13:00:00"
+},
+{
+"id": 2848,
+"message": "<p>Please note that the Polonsky Exhibition of The New York Public Library's Treasures will open at 12:00 PM on Thursday, August 28. We apologize for the inconvenience.</p>",
+"publish_start": "2025-08-23T12:00:00",
+"publish_end": "2025-08-28T16:00:00"
+}
+],
+"closings": null,
+"explore": {
+"view_display_title": "Explore Divisions & Centers",
+"view_machine_name": "block_library_divisions_centers",
+"items": [
+{
+"id": "f27e87bc-a7ed-44bb-8c87-a2237a4e63f1",
+"title": "Carl H. Pforzheimer Collection of Shelley and His Circle",
+"slug": "/locations/schwarzman/pforzheimer-collection-shelley-and-his-circle",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_pforzheimer_I45A8082_0.jpg?h=5bf6543a&itok=tTN8cWFg",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "575a664c-dc12-481a-b49b-0aa432bca819",
+"title": "Dorot Jewish Division",
+"slug": "/locations/schwarzman/jewish-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_jewish_I45A7970.jpg?h=5bf6543a&itok=GF1CZviq",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "First Floor"
+},
+{
+"id": "7053a199-5766-4cb8-9a4a-cd9ccdf249d3",
+"title": "General Research Division",
+"slug": "/locations/schwarzman/general-research-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/GeneralResearch_Preview.jpg?h=5bf6543a&itok=0gnSKC6c",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "Third Floor"
+},
+{
+"id": "877db794-1579-48bd-8715-6332ddb1ef48",
+"title": "Henry W. and Albert A. Berg Collection of English and American Literature",
+"slug": "/locations/schwarzman/berg-collection-english-and-american-literature",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_berg_I45A8437.jpg?h=5bf6543a&itok=Pz8SWUbC",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "81f53447-74e8-4382-8d76-327ffe7ea3be",
+"title": "Irma and Paul Milstein Division of United States History, Local History and Genealogy",
+"slug": "/locations/schwarzman/milstein",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/USHistory_Preview.jpg?h=5bf6543a&itok=xd-UG8em",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "First Floor"
+},
+{
+"id": "fd091eeb-e313-4719-b201-492d4ccd196f",
+"title": "Lionel Pincus and Princess Firyal Map Division",
+"slug": "/locations/schwarzman/map-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_map_1049.jpg?h=5bf6543a&itok=7D_7cqRu",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "First Floor"
+},
+{
+"id": "da24b3e5-db41-4ad2-a518-b5ef878c9f0c",
+"title": "Manuscripts and Archives Division",
+"slug": "/locations/schwarzman/manuscripts-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/Manuscripts_Preview_0.jpg?h=5bf6543a&itok=mmuTEz2B",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "5345f4a3-f2d8-4f1f-868f-2a5689bc364a",
+"title": "Rare Book Division",
+"slug": "/locations/schwarzman/rare-books-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/research_interior_2014_09_18_sasb_rarebooks_I45A8003.jpg?h=5bf6543a&itok=g95Q5q7J",
+"summary": null,
+"division_hours": "11 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "d9067e9b-3cc7-477e-88ab-7d81d92b3f37",
+"title": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs",
+"slug": "/locations/schwarzman/wallach-division",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2020-07/APP_Preview.jpg?h=5bf6543a&itok=VTXuh1As",
+"summary": null,
+"division_hours": "10 AM–5 PM",
+"floor": "Third Floor"
+},
+{
+"id": "c5716a12-bd5d-457a-af9c-d1a0305ffebf",
+"title": "Vartan Gregorian Center for Research in the Humanities",
+"slug": "/locations/schwarzman/center-research-humanities",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2023-11/Gregorian_Center_Noma_1000x500.jpeg?h=5dabf909&itok=4Tn5A_DA",
+"summary": null,
+"division_hours": "10 AM–7 PM",
+"floor": "Second Floor"
+},
+{
+"id": "ab075f99-2ff1-4bfb-b580-e92860bbae33",
+"title": "Visitor Center",
+"slug": "/locations/schwarzman/visitor-center",
+"image_url": "https://drupal.nypl.org/sites-drupal/default/files/styles/2_1_1120/public/2023-06/SASB_2023_05_01_Welcome_Center-00351.jpg?h=56d0ca2e&itok=z7Tqt0nW",
+"summary": "<p>We look forward to welcoming you to The New York Public Library. Get the most out of your visit with these helpful tips, including what to bring with you, how to get here, accessibility information, exhibition tours, and more.</p>\n",
+"division_hours": "10 AM–8 PM",
+"floor": "First Floor"
+}
+]
+}
+},
+"relationships": {
+"node_type": {
+"data": {
+"type": "node_type--node_type",
+"id": "cf7f123c-64c1-4fc7-93d4-bff46b7f900b",
+"meta": {
+"drupal_internal__target_id": "library"
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/node_type?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/node_type?resourceVersion=id%3A123031"
+}
+}
+},
+"revision_uid": {
+"data": {
+"type": "user--user",
+"id": "e9ea1163-2137-44cf-a80a-730f302dada6",
+"meta": {
+"drupal_internal__target_id": 1170
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/revision_uid?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/revision_uid?resourceVersion=id%3A123031"
+}
+}
+},
+"uid": {
+"data": {
+"type": "user--user",
+"id": "bf11eb62-42f9-48b7-8ba5-db5b68a6b38d",
+"meta": {
+"drupal_internal__target_id": 1
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/uid?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/uid?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_optional_announcements": {
+"data": [
+{
+"type": "paragraph--text_with_image",
+"id": "7170e705-bd2d-46f9-b27f-c7922acda639",
+"meta": {
+"target_revision_id": 1033847,
+"drupal_internal__target_id": 80257
+}
+},
+{
+"type": "paragraph--text_with_image",
+"id": "f4cd3b48-fe44-4d60-aac9-a74670792d37",
+"meta": {
+"target_revision_id": 1033848,
+"drupal_internal__target_id": 76229
+}
+},
+{
+"type": "paragraph--text_with_image",
+"id": "b11525c0-1eca-4af9-9496-35d36aae1c36",
+"meta": {
+"target_revision_id": 1033849,
+"drupal_internal__target_id": 7257
+}
+}
+],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_optional_announcements?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_optional_announcements?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_staff_picks": {
+"data": [],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_staff_picks?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_staff_picks?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_explore_tab_intro": {
+"data": {
+"type": "paragraph--first_paragraph",
+"id": "79622794-08fc-45f6-ac61-3a9b60630945",
+"meta": {
+"target_revision_id": 1033807,
+"drupal_internal__target_id": 3159
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_explore_tab_intro?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_explore_tab_intro?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_explore_2": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "19f6dff7-4541-4311-a8b3-0493c29a1946",
+"meta": {
+"target_revision_id": 1033820,
+"drupal_internal__target_id": 3135
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_explore_2?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_explore_2?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_visit_1": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "332f8cca-855c-425c-ada1-0b15a49143e1",
+"meta": {
+"target_revision_id": 1033825,
+"drupal_internal__target_id": 3150
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_visit_1?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_visit_1?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_visit_2": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "306655ec-1bff-4166-a7fd-f8d9fb98a0f1",
+"meta": {
+"target_revision_id": 1033830,
+"drupal_internal__target_id": 3146
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_visit_2?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_visit_2?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_logo": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_logo?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_logo?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_promo_space": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_promo_space?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_promo_space?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_feature_managers": {
+"data": [],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_feature_managers?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_feature_managers?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_library_amenities": {
+"data": [
+{
+"type": "paragraph--library_amenity",
+"id": "4d42ffcc-fe05-4a05-8719-de8e41814e69",
+"meta": {
+"target_revision_id": 1033831,
+"drupal_internal__target_id": 1080
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "f592e21d-5579-4be0-b545-52bfee0caeb7",
+"meta": {
+"target_revision_id": 1033832,
+"drupal_internal__target_id": 1081
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "6b28e81f-e13d-4d81-9eef-b3008da87a93",
+"meta": {
+"target_revision_id": 1033833,
+"drupal_internal__target_id": 1082
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "209844c0-e696-49c3-b913-d1f2178142e8",
+"meta": {
+"target_revision_id": 1033834,
+"drupal_internal__target_id": 1083
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "32f0844f-540a-4661-b59a-8503d2ecc960",
+"meta": {
+"target_revision_id": 1033835,
+"drupal_internal__target_id": 1084
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "7f653187-29e2-4afb-92d2-82813de85a01",
+"meta": {
+"target_revision_id": 1033836,
+"drupal_internal__target_id": 1085
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "9e7c3cf9-ee81-470f-967d-22e2902957dc",
+"meta": {
+"target_revision_id": 1033837,
+"drupal_internal__target_id": 1086
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "ba50412a-994b-4533-8961-cd15a0de7025",
+"meta": {
+"target_revision_id": 1033838,
+"drupal_internal__target_id": 1087
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "5262dacc-838e-44bf-b185-76b974da6701",
+"meta": {
+"target_revision_id": 1033839,
+"drupal_internal__target_id": 1088
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "ad84de62-b397-4abd-9327-886042b99155",
+"meta": {
+"target_revision_id": 1033840,
+"drupal_internal__target_id": 1089
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "54841e76-7c3d-4e44-b73a-c81129c8bbbc",
+"meta": {
+"target_revision_id": 1033841,
+"drupal_internal__target_id": 1090
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "99ad427b-3856-447a-bb29-986c90bd069b",
+"meta": {
+"target_revision_id": 1033842,
+"drupal_internal__target_id": 1092
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "34dadfc6-93f7-4f3b-99aa-0ed8e34335ec",
+"meta": {
+"target_revision_id": 1033843,
+"drupal_internal__target_id": 1093
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "8cb46c2f-d9a1-4489-90db-fffa9b6440f1",
+"meta": {
+"target_revision_id": 1033844,
+"drupal_internal__target_id": 1094
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "463169cf-de3e-4c6c-a42e-806027c6e3bd",
+"meta": {
+"target_revision_id": 1033845,
+"drupal_internal__target_id": 1095
+}
+},
+{
+"type": "paragraph--library_amenity",
+"id": "2b36e7a5-04a2-44bf-8064-2aed640bec03",
+"meta": {
+"target_revision_id": 1033846,
+"drupal_internal__target_id": 1096
+}
+}
+],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_library_amenities?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_library_amenities?resourceVersion=id%3A123031"
+}
+}
+},
+"field_erm_sponsors": {
+"data": [],
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_erm_sponsors?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_erm_sponsors?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_about_the_library": {
+"data": {
+"type": "paragraph--text_with_image",
+"id": "026db135-1824-412e-a44f-7bb86c956af4",
+"meta": {
+"target_revision_id": 1033806,
+"drupal_internal__target_id": 2682
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_about_the_library?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_about_the_library?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_additional_info": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_additional_info?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_additional_info?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_hero_image": {
+"data": {
+"type": "media--decorative_image",
+"id": "41acd9e0-7120-47ef-a36c-b11e490e66be",
+"meta": {
+"drupal_internal__target_id": 2441
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_hero_image?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_hero_image?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_interior_media_image": {
+"data": {
+"type": "media--image",
+"id": "283fc99e-4ee9-4df9-8c36-d4f9e9943ceb",
+"meta": {
+"drupal_internal__target_id": 2073
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_interior_media_image?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_interior_media_image?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_link_list_explore_1": {
+"data": {
+"type": "paragraph--link_card_list",
+"id": "fff569ac-92ea-494d-8af8-49cecdbd0d16",
+"meta": {
+"target_revision_id": 1033814,
+"drupal_internal__target_id": 3130
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_link_list_explore_1?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_link_list_explore_1?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_media_image": {
+"data": {
+"type": "media--image",
+"id": "ca19ec42-0f74-4371-b48c-68bdc01aea53",
+"meta": {
+"drupal_internal__target_id": 2074
+}
+},
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_media_image?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_media_image?resourceVersion=id%3A123031"
+}
+}
+},
+"field_ers_read_tab_intro": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_ers_read_tab_intro?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_ers_read_tab_intro?resourceVersion=id%3A123031"
+}
+}
+},
+"field_first_paragraph": {
+"data": null,
+"links": {
+"related": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/field_first_paragraph?resourceVersion=id%3A123031"
+},
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library/50b5b1c6-e01f-4728-befb-90578bb0d1d4/relationships/field_first_paragraph?resourceVersion=id%3A123031"
+}
+}
+}
+}
+}
+],
+"meta": {
+"count": 1
+},
+"links": {
+"self": {
+"href": "https://drupal.nypl.org/jsonapi/node/library?filter%5Bfield_ts_location_code%5D=ma"
+}
+}
+}

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -11,6 +11,7 @@ class TestHelpers:
         'S3_BUCKET': 'bucket',
         'S3_LOCATIONS_FILE': 'file',
         'REFINERY_API_BASE_URL': 'https://refineryapi.net/',
+        'DRUPAL_API_BASE_URL': 'https://drupalapi.net/',
         'RC_ALERTS_URL': 'https://www.fake_rc_alerts.com'
     }
 

--- a/test/unit/test_location_api.py
+++ b/test/unit/test_location_api.py
@@ -1,11 +1,11 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 import json
 import os
 from freezegun import freeze_time
-from unittest.mock import patch
 
 from lib.location_api import parse_hours, parse_address, get_location_data
 from test.unit.test_helpers import TestHelpers
+
 
 class TestLocationApi:
 
@@ -28,11 +28,11 @@ class TestLocationApi:
             return json.load(file)
 
     def test_parse_hours(self):
-        monday =     {
+        monday = {
             "day": "Monday",
             "hours": "10 AM–6 PM"
         }
-        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        current_date = datetime(2000, 1, 1).astimezone()  # this is a saturday
         parsed = parse_hours(current_date, monday)
         assert parsed['day'] == 'Monday'
         assert parsed['startTime'] == '2000-01-03T10:00:00-05:00'
@@ -43,7 +43,7 @@ class TestLocationApi:
             "day": "Saturday",
             "hours": "10 AM–6 PM"
         }
-        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        current_date = datetime(2000, 1, 1).astimezone()  # this is a saturday
         parsed = parse_hours(current_date, day)
         assert parsed['day'] == 'Saturday'
         assert parsed['startTime'] == '2000-01-01T10:00:00-05:00'
@@ -55,7 +55,7 @@ class TestLocationApi:
             "day": "Saturday",
             "hours": "12 AM–12 PM"
         }
-        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        current_date = datetime(2000, 1, 1).astimezone()  # this is a saturday
         parsed = parse_hours(current_date, day)
         assert parsed['day'] == 'Saturday'
         assert parsed['startTime'] == '2000-01-01T00:00:00-05:00'
@@ -67,7 +67,7 @@ class TestLocationApi:
             "day": "Saturday",
             "hours": "12 PM–8 PM"
         }
-        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        current_date = datetime(2000, 1, 1).astimezone()  # this is a saturday
         parsed = parse_hours(current_date, day)
         assert parsed['day'] == 'Saturday'
         assert parsed['startTime'] == '2000-01-01T12:00:00-05:00'

--- a/test/unit/test_location_api.py
+++ b/test/unit/test_location_api.py
@@ -1,0 +1,123 @@
+from datetime import datetime, timezone, timedelta
+import json
+import os
+from freezegun import freeze_time
+from unittest.mock import patch
+
+from lib.location_api import parse_hours, parse_address, get_location_data
+from test.unit.test_helpers import TestHelpers
+
+class TestLocationApi:
+
+    def timedelta_side_effect(day_offset):
+        return timedelta(days=day_offset)
+
+    @classmethod
+    def setup_class(cls):
+        TestHelpers.set_env_vars()
+        TestHelpers.set_up()
+
+    @classmethod
+    def teardown_class(cls):
+        TestHelpers.clear_env_vars()
+        TestHelpers.tear_down()
+
+    def fetch_data_success(code):
+        with open(f'test/data/drupal_responses/{code}.json',
+                  'r') as file:
+            return json.load(file)
+
+    def test_parse_hours(self):
+        monday =     {
+            "day": "Monday",
+            "hours": "10 AM–6 PM"
+        }
+        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        parsed = parse_hours(current_date, monday)
+        assert parsed['day'] == 'Monday'
+        assert parsed['startTime'] == '2000-01-03T10:00:00-05:00'
+        assert parsed['endTime'] == '2000-01-03T18:00:00-05:00'
+
+    def test_parse_hours_today(self):
+        day = {
+            "day": "Saturday",
+            "hours": "10 AM–6 PM"
+        }
+        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        parsed = parse_hours(current_date, day)
+        assert parsed['day'] == 'Saturday'
+        assert parsed['startTime'] == '2000-01-01T10:00:00-05:00'
+        assert parsed['endTime'] == '2000-01-01T18:00:00-05:00'
+        assert parsed['today']
+
+    def test_parse_hours_midnight(self):
+        day = {
+            "day": "Saturday",
+            "hours": "12 AM–12 PM"
+        }
+        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        parsed = parse_hours(current_date, day)
+        assert parsed['day'] == 'Saturday'
+        assert parsed['startTime'] == '2000-01-01T00:00:00-05:00'
+        assert parsed['endTime'] == '2000-01-01T12:00:00-05:00'
+        assert parsed['today']
+
+    def test_parse_hours_noon(self):
+        day = {
+            "day": "Saturday",
+            "hours": "12 PM–8 PM"
+        }
+        current_date = datetime(2000, 1, 1).astimezone() # this is a saturday
+        parsed = parse_hours(current_date, day)
+        assert parsed['day'] == 'Saturday'
+        assert parsed['startTime'] == '2000-01-01T12:00:00-05:00'
+        assert parsed['endTime'] == '2000-01-01T20:00:00-05:00'
+        assert parsed['today']
+
+    def test_parse_address(self):
+        address_data = {
+            "langcode": "en",
+            "country_code": "US",
+            "administrative_area": "NY",
+            "locality": "New York",
+            "postal_code": "10018",
+            "address_line1": "Fifth Avenue and 42nd Street",
+            "address_line3": ""
+        }
+        parsed = parse_address(address_data)
+        assert parsed['line1'] == "Fifth Avenue and 42nd Street"
+        assert parsed['city'] == 'New York'
+        assert parsed['state'] == 'NY'
+        assert parsed['postal_code'] == '10018'
+
+    @freeze_time(datetime(2000, 1, 1))
+    def test_get_location_data_special_hours(self, requests_mock):
+        requests_mock.get(os.environ['DRUPAL_API_BASE_URL'] + '?filter[field_ts_location_code]=ma',
+                          json=TestLocationApi.fetch_data_success('ma'))
+        location_data = get_location_data('ma', ['hours', 'location'])
+        correct_today = False
+        correct_next_business_day = False
+        for hours in location_data.get('hours'):
+            if hours['day'] == 'Saturday' and hours['today']:
+                correct_today = True
+            if hours['day'] == 'Tuesday' and hours['nextBusinessDay']:
+                # test day is closed on sunday and monday so it wraps to tuesday
+                correct_next_business_day = True
+        assert correct_today
+        assert correct_next_business_day
+
+    @freeze_time(datetime(2000, 1, 1))
+    def test_get_location_data_regular_hours(self, requests_mock):
+        requests_mock.get(os.environ['DRUPAL_API_BASE_URL'] + '?filter[field_ts_location_code]=ma',
+                          json=TestLocationApi.fetch_data_success('ma_regular_hours'))
+        location_data = get_location_data('ma', ['hours', 'location'])
+        correct_today = False
+        correct_next_business_day = False
+        for hours in location_data.get('hours'):
+            if hours['day'] == 'Saturday' and hours['today']:
+                correct_today = True
+            if hours['day'] == 'Monday' and hours['nextBusinessDay']:
+                # test day is closed on sunday so it wraps to monday
+                correct_next_business_day = True
+        assert correct_today
+        assert correct_next_business_day

--- a/test/unit/test_location_lookup.py
+++ b/test/unit/test_location_lookup.py
@@ -9,7 +9,7 @@ s3_locations = {'lo*': 'url.com',
                 'sc*': 'schom.com',
                 'my*': 'lpa.com'}
 
-refinery_data = {
+location_data = {
     'hours': 'some hours',
     'location': 'a location'
 }
@@ -26,7 +26,7 @@ class TestLocationLogic:
         TestHelpers.clear_env_vars()
         TestHelpers.tear_down()
 
-    @patch('lib.location_lookup.get_refinery_data', return_value=refinery_data)
+    @patch('lib.location_lookup.get_location_data', return_value=location_data)
     @patch('lib.location_lookup.check_cache_or_fetch_s3',
            return_value=s3_locations)
     @patch('lib.nypl_core.sierra_location_by_code',
@@ -40,7 +40,7 @@ class TestLocationLogic:
         assert build_location_info('xma99', ['location']) \
             == [{'code': None, 'label': 'label', 'location': 'a location'}]
 
-    @patch('lib.location_lookup.get_refinery_data', return_value=refinery_data)
+    @patch('lib.location_lookup.get_location_data', return_value=location_data)
     @patch('lib.location_lookup.check_cache_or_fetch_s3',
            return_value=s3_locations)
     @patch('lib.nypl_core.sierra_location_by_code',
@@ -74,7 +74,7 @@ class TestLocationLogic:
                 }]
         }
 
-    @patch('lib.location_lookup.get_refinery_data', return_value=refinery_data)
+    @patch('lib.location_lookup.get_location_data', return_value=location_data)
     @patch('lib.location_lookup.check_cache_or_fetch_s3',
            return_value=s3_locations)
     @patch('lib.nypl_core.sierra_location_by_code',
@@ -107,7 +107,7 @@ class TestLocationLogic:
                 }]
         }
 
-    @patch('lib.location_lookup.get_refinery_data', return_value=refinery_data)
+    @patch('lib.location_lookup.get_location_data', return_value=location_data)
     @patch('lib.location_lookup.check_cache_or_fetch_s3',
            return_value=s3_locations)
     @patch('lib.nypl_core.sierra_location_by_code',


### PR DESCRIPTION
* Ticket: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4812
* This PR updates the location service to call drupal for location information. The intent is to keep the response looking exactly the same as before but just swap out the dependency under the hood.
* To that end, there were still a number of adjustments needed here, specifically around how we're managing datetimes.

### Testing
* Added unit tests to cover different scenarios / possible responses
* Used `sam` to test the lambda locally against the real drupal api.