### PR TITLE
Trying to fix gha build failure for QA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ oauthlib==3.2.2
 packaging==23.1
 pluggy==1.2.0
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.2
 requests==2.31.0
 requests-mock==1.11.0
 requests-oauthlib==1.3.1


### PR DESCRIPTION
* The terraform packaging is failing in QA while installing PyYAML: https://github.com/NYPL/locations-service/actions/runs/17868440607/job/51060973351 so I'm updating the dep to the latest version to see whether that fixes it.
* Important to note that I can't reproduce this locally regardless of PyYAML version so its a bit of a shot in the dark- but being on the latest can't hurt.